### PR TITLE
feat: login page

### DIFF
--- a/src/client/data/user.ts
+++ b/src/client/data/user.ts
@@ -42,6 +42,9 @@ export const useLogin = (): UseMutationResult<
     onSuccess(response) {
       setToken(response.data);
     },
+    onError() {
+      // do nothing
+    },
   });
 };
 

--- a/src/client/pages/Login/Login.tsx
+++ b/src/client/pages/Login/Login.tsx
@@ -58,8 +58,7 @@ export const Login: FC = () => {
         remember,
       }));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [history]);
 
   const doLogin = () => {
     login(
@@ -186,28 +185,30 @@ export const LoginView: FC<LoginViewProps> = ({
               />
             </div>
           </div>
-          <div className="flex items-center justify-between ml-24 font-light text-gray-500 mb-8">
-            <div className="flex items-center">
-              <input
-                id="remember"
-                name="remember"
-                type="checkbox"
-                className="h-4 w-4 focus:ring-transparent text-bw border-gray-300 rounded"
-                checked={data.remember}
-                onChange={e => {
-                  const isChecked = e.target.checked;
-                  window.localStorage.setItem(
-                    "rememberMe",
-                    isChecked === true ? "true" : "false",
-                  );
-                  onChangeData?.("remember", isChecked);
-                }}
-              />
-              <label htmlFor="remember" className="ml-2 block text-sm">
-                Remember me
-              </label>
+          {hasUser && (
+            <div className="flex items-center justify-between ml-24 font-light text-gray-500 mb-8">
+              <div className="flex items-center">
+                <input
+                  id="remember"
+                  name="remember"
+                  type="checkbox"
+                  className="h-4 w-4 focus:ring-transparent text-bw border-gray-300 rounded"
+                  checked={data.remember}
+                  onChange={e => {
+                    const isChecked = e.target.checked;
+                    window.localStorage.setItem(
+                      "rememberMe",
+                      isChecked === true ? "true" : "false",
+                    );
+                    onChangeData?.("remember", isChecked);
+                  }}
+                />
+                <label htmlFor="remember" className="ml-2 block text-sm">
+                  Remember me
+                </label>
+              </div>
             </div>
-          </div>
+          )}
           <div className="ml-24">
             {!!errorMessage && (
               <p className="text-red-500 mb-4">{errorMessage}</p>

--- a/src/client/pages/Login/Login.tsx
+++ b/src/client/pages/Login/Login.tsx
@@ -33,6 +33,7 @@ export const Login: FC = () => {
     password: "",
     remember: false,
   });
+  const [errorMessage, setErrorMessage] = useState<string>("");
 
   const { mutate: login, isLoading } = useLogin();
 
@@ -40,18 +41,23 @@ export const Login: FC = () => {
     <LoginView
       data={data}
       onChangeData={(field, value) => {
+        setErrorMessage("");
         setData(prev => ({
           ...prev,
           [field]: value,
         }));
       }}
       isLoading={isLoading}
+      errorMessage={errorMessage}
       onSubmit={() => {
         login(
           { email: data.email, password: data.password },
           {
             onSuccess() {
               history.replace("/");
+            },
+            onError(error) {
+              setErrorMessage(error.message);
             },
           },
         );
@@ -70,6 +76,7 @@ export interface LoginViewProps {
   data?: LoginFormData;
   onChangeData?(field: string, value: unknown): void;
   isLoading?: boolean;
+  errorMessage?: string;
   onSubmit?(): void;
 }
 
@@ -77,6 +84,7 @@ export const LoginView: FC<LoginViewProps> = ({
   data = { email: "", password: "", remember: false },
   onChangeData,
   isLoading = false,
+  errorMessage,
   onSubmit,
 }) => (
   <div>
@@ -104,6 +112,8 @@ export const LoginView: FC<LoginViewProps> = ({
                 autoComplete="email"
                 value={data.email}
                 onChange={e => onChangeData?.("email", e.target.value)}
+                type="email"
+                required
               />
             </div>
           </div>
@@ -120,6 +130,7 @@ export const LoginView: FC<LoginViewProps> = ({
                 type="password"
                 value={data.password}
                 onChange={e => onChangeData?.("password", e.target.value)}
+                required
               />
             </div>
           </div>
@@ -139,6 +150,9 @@ export const LoginView: FC<LoginViewProps> = ({
             </div>
           </div>
           <div className="ml-24">
+            {!!errorMessage && (
+              <p className="text-red-500 mb-4">{errorMessage}</p>
+            )}
             <Button label="Login" type="submit" disabled={isLoading} />
           </div>
         </div>

--- a/src/client/pages/Login/Login.tsx
+++ b/src/client/pages/Login/Login.tsx
@@ -17,7 +17,7 @@
  *                                                                                *
  **********************************************************************************/
 
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import Button from "../../components/Button";
@@ -36,6 +36,22 @@ export const Login: FC = () => {
   const [errorMessage, setErrorMessage] = useState<string>("");
 
   const { mutate: login, isLoading } = useLogin();
+
+  useEffect(() => {
+    const rememberMeStoredValue = window.localStorage.getItem("rememberMe");
+    const remember = rememberMeStoredValue === "true" ? true : false;
+    const accessToken = window.localStorage.getItem("at");
+
+    if (remember && !!accessToken) {
+      history.replace("/");
+    } else {
+      setData(prev => ({
+        ...prev,
+        remember,
+      }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <LoginView
@@ -142,7 +158,14 @@ export const LoginView: FC<LoginViewProps> = ({
                 type="checkbox"
                 className="h-4 w-4 focus:ring-transparent text-bw border-gray-300 rounded"
                 checked={data.remember}
-                onChange={e => onChangeData?.("remember", e.target.checked)}
+                onChange={e => {
+                  const isChecked = e.target.checked;
+                  window.localStorage.setItem(
+                    "rememberMe",
+                    isChecked === true ? "true" : "false",
+                  );
+                  onChangeData?.("remember", isChecked);
+                }}
               />
               <label htmlFor="remember" className="ml-2 block text-sm">
                 Remember me

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -39,7 +39,7 @@ router.get("/", (_, res) => {
 router.use(auth);
 router.use(monika);
 
-router.use(authMiddleware);
+// router.use(authMiddleware);
 
 // ********************************
 // Protected Endpoints ************

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -39,7 +39,7 @@ router.get("/", (_, res) => {
 router.use(auth);
 router.use(monika);
 
-// router.use(authMiddleware);
+router.use(authMiddleware);
 
 // ********************************
 // Protected Endpoints ************

--- a/src/server/services/auth/__tests__/acceptance.test.ts
+++ b/src/server/services/auth/__tests__/acceptance.test.ts
@@ -190,7 +190,7 @@ describe("Auth Service", () => {
       });
 
       // assert
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       done();
     });
 
@@ -201,7 +201,7 @@ describe("Auth Service", () => {
       });
 
       // assert
-      expect(res.status).toBe(401);
+      expect(res.status).toBe(400);
       done();
     });
 

--- a/src/server/services/auth/controller.ts
+++ b/src/server/services/auth/controller.ts
@@ -105,20 +105,6 @@ export async function login(
   res: Response,
   next: NextFunction,
 ): Promise<void> {
-  const {
-    body: { email, password },
-  } = req;
-
-  if (!email || !password) {
-    const error = new AppError(
-      commonHTTPErrors.badRequest,
-      "Bad request, missing mandatory information",
-      true,
-    );
-
-    return next(error);
-  }
-
   return passport.authenticate(
     "local",
     { session: false },
@@ -154,17 +140,6 @@ export async function refresh(
   const {
     body: { refreshToken },
   } = req;
-
-  if (!refreshToken) {
-    const error = new AppError(
-      commonHTTPErrors.badRequest,
-      "Bad request, missing mandatory information",
-      true,
-    );
-
-    return next(error);
-  }
-
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const decoded: any = jwt.verify(refreshToken, JWT_SECRET); // TODO: create definition for JWT

--- a/src/server/services/auth/controller.ts
+++ b/src/server/services/auth/controller.ts
@@ -48,7 +48,7 @@ export async function checkHasUser(
     res.status(200).send({
       result: "SUCCESS",
       message: "Successfully get users",
-      isUsers: data.length > 0 ? true : false,
+      hasUser: data.length > 0 ? true : false,
     });
   } catch (err) {
     const error = new AppError(

--- a/src/server/services/auth/index.ts
+++ b/src/server/services/auth/index.ts
@@ -18,11 +18,15 @@
  **********************************************************************************/
 
 import express from "express";
-import { login, refresh } from "./controller";
+import validate from "../../internal/middleware/validator";
+import { createSchemaValidator } from "../users/validator";
+import { login, refresh, checkHasUser, createFirstUser } from "./controller";
 
 const router = express.Router();
 
+router.get("/v1/auth/check-users", checkHasUser);
 router.post("/v1/auth", login);
+router.post("/v1/auth/user", validate(createSchemaValidator), createFirstUser);
 router.post("/v1/refresh", refresh);
 
 export default router;

--- a/src/server/services/auth/validator.ts
+++ b/src/server/services/auth/validator.ts
@@ -17,20 +17,13 @@
  *                                                                                *
  **********************************************************************************/
 
-import express from "express";
-import validate from "../../internal/middleware/validator";
-import { createSchemaValidator } from "../users/validator";
-import { login, refresh, checkHasUser, createFirstUser } from "./controller";
-import {
-  loginRequesBodytValidator,
-  refreshRequestBodyValidator,
-} from "./validator";
+import Joi from "joi";
 
-const router = express.Router();
+export const loginRequesBodytValidator = Joi.object().keys({
+  email: Joi.string().required(),
+  password: Joi.string().required(),
+});
 
-router.get("/v1/auth/check-users", checkHasUser);
-router.post("/v1/auth", validate(loginRequesBodytValidator), login);
-router.post("/v1/auth/user", validate(createSchemaValidator), createFirstUser);
-router.post("/v1/refresh", validate(refreshRequestBodyValidator), refresh);
-
-export default router;
+export const refreshRequestBodyValidator = Joi.object().keys({
+  refreshToken: Joi.string().required(),
+});


### PR DESCRIPTION
# Symon Pull Request (PR)

### what issue does this pr address

implementing issue no #177  which adds feature login page

### how did you implement / how did you fix it

1. create rememberMe function to save state in localStorage
2. create 2 API endpoints to check is there already user and create first user if no user in DB
3. wire the API to FE

### how **DID** you test

1. npm start
2. check localhost:4000/login
3. if you already seed the DB, login with the seeded user credential (email:admin@symon.org | password:right password). You can check that the access token is stored on localStorage and you will be redirected to home page.
4. open localhost:4000/login again and you will not redirected to home page because "remember me" check is uncheck. Now repeat above step to login again, and when you visit login page again, you will be auto redirected to home page
5. Now test for case of no pre seed user. Delete the DB, then visit login page again and you will see "crate new user" form. Fill the form and the user is created and you will be automatically logged in.

### any other info/context

On a second thought, the seed user is a user zero which can be treated as "already created user". So the one case to display create user form is when there is no user at all in DB. If the seeded user is not treated as user zero, than we cannot log in with that user in the first time, so there is no point in creating the seed
