### PR TITLE
Add bash package as default shell

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -44,6 +44,9 @@ COPY package-lock.json .
 COPY package.json .
 COPY tsconfig.json .
 
+# install bash as default shell
+RUN apk add --no-cache bash
+
 # Copy the client code
 RUN mkdir src
 COPY src/config src/config


### PR DESCRIPTION
easy troubleshooting inside alpine linux

# install bash as default shell
RUN apk add --no-cache bash

# Symon Pull Request (PR)

### what issue does this pr address

1. implementing shell console to make troubleshooting more simple from inside the container

### how did you implement / how did you fix it

1. add on Docker File:
RUN apk add --no-cache bash

### how **DID** you test

1. sudo docker run -d --name monika --restart unless-stopped hyperjump/monika:latest monika --symonUrl="https://xx.xx.hyperjump.tech" --symonLocationId="xxx-1e69-47ee-b49d-xxx" --symonKey="42881334-2bab-4a41-8a8c-xx"exit
2. docker exec -it <container-id> bash

### any other info/context


